### PR TITLE
Atulizando versão do Gunicorn para 23.0.0

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,17 +1,19 @@
 FROM python:3.10-slim
+
 WORKDIR /app
+
 RUN apt-get update
 RUN apt-get install locales locales-all -y
-
 RUN apt update && apt install tzdata -y
-ENV TZ="America/Sao_Paulo"
 
+ENV TZ="America/Sao_Paulo"
 ENV LC_ALL pt_BR.UTF-8
 ENV LANG pt_BR.UTF-8
 ENV LANGUAGE pt_BR.UTF-8
 
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .
+
 EXPOSE 8080
-CMD ["flask", "--app", "flask_backend", "run", "--host=0.0.0.0", "--port", "8080"]
+CMD ["gunicorn", "flask_backend:create_app()", "--workers", "4", "--bind", "0.0.0.0:8080"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 country-list==1.0.0
 Faker==24.7.1
 Flask==3.0.3
-gunicorn==21.2.0
+gunicorn==23.0.0
 idna==3.4
 itsdangerous==2.1.2
 Jinja2==3.1.3


### PR DESCRIPTION
Recentemente fiz o commit 26d400cc0b39ddb929ee7d658158fb11248f9f55 que fez com que o projeto passa-se a utilizar o webserver gunicorn, optei por utilizar a versão que já estava no requirements.txt `gunicorn==21.2.0` porem versões abaixo da 22.0.0 estão vulneráveis a seguinte falha de segurança [CVE-2024-1135](https://github.com/advisories/GHSA-w3h3-4rj7-4ph4) apenas atualizar a versão do gunicorn resolve o problema.