### PR TITLE
Atulizando versão do Gunicorn para 23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 country-list==1.0.0
 Faker==24.7.1
 Flask==3.0.3
-gunicorn==21.2.0
+gunicorn==23.0.0
 idna==3.4
 itsdangerous==2.1.2
 Jinja2==3.1.3


### PR DESCRIPTION
Recentemente fiz o commit https://github.com/cumbucadev/cinemaempoa/commit/26d400cc0b39ddb929ee7d658158fb11248f9f55 que fez com que o projeto passa-se a utilizar o webserver gunicorn, optei por utilizar a versão que já estava no requirements.txt gunicorn==21.2.0 porem versões abaixo da 22.0.0 estão vulneráveis a seguinte falha de segurança [CVE-2024-1135](https://github.com/advisories/GHSA-w3h3-4rj7-4ph4) apenas atualizar a versão do gunicorn resolve o problema.