### PR TITLE
#96 - Adiciona atributo height na tag img dos banners de filmes na tela inicial

### DIFF
--- a/flask_backend/templates/screening/index.html
+++ b/flask_backend/templates/screening/index.html
@@ -39,7 +39,7 @@
       >
         <img class="img-fluid rounded float-sm-start shadow-sm mb-3 me-0
         me-sm-3" src="{{ screening_date['image'] }}" width="{{
-        screening_date['image_display_width'] }}" loading="lazy" {% if
+        screening_date['image_display_width'] }}" height="{{screening_date['min_height']}}" loading="lazy" {% if
         screening_date['image_alt'] %} alt="{{ screening_date['image_alt'] }}"
         title="{{ screening_date['image_alt'] }}" {% endif %} /> {% else %}
       </li>


### PR DESCRIPTION
## Sobre
Conforme solicitado na issue #96, foi adicionado o atributo `height` às tags `img` da página inicial que contém os banners dos filmes listados

## Prints

![image](https://github.com/user-attachments/assets/1f294db9-cf5a-40e3-9880-f7549e1c529e)

![image](https://github.com/user-attachments/assets/28e7a0eb-2af9-4487-a7b6-42ee15ae6944)
