### PR TITLE
#44 adicionar tag analytics do goat counter

### DIFF
--- a/flask_backend/static/cubism/sketch-maintain-crop-positions.js
+++ b/flask_backend/static/cubism/sketch-maintain-crop-positions.js
@@ -70,6 +70,13 @@ function setup() {
 
 function _mouseClicked() {
   draw();
+  if (window.goatcounter) {
+    window.goatcounter.count({
+      path: window.location.pathname,
+      title: "Cubism maintain crop positions click",
+      event: true,
+    });
+  }
 }
 
 function draw() {

--- a/flask_backend/static/cubism/sketch-random-crop-positions.js
+++ b/flask_backend/static/cubism/sketch-random-crop-positions.js
@@ -66,6 +66,13 @@ function setup() {
 
 function _mouseClicked() {
   draw();
+  if (window.goatcounter) {
+    window.goatcounter.count({
+      path: window.location.pathname,
+      title: "Cubism random crop positions click",
+      event: true,
+    });
+  }
 }
 
 function draw() {

--- a/flask_backend/templates/base.html
+++ b/flask_backend/templates/base.html
@@ -268,6 +268,13 @@
         (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl)
       );
     </script>
+    <script>
+      // reference: https://www.goatcounter.com/help/skip-path
+      // doesn't load analytics if there's an element containing `data-goatcounter-skip` attribute
+      window.goatcounter = {
+        no_onload: document.querySelector("[data-goatcounter-skip]") !== null,
+      }
+    </script>
     <script data-goatcounter="https://cinemaempoa.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 
     <!-- REMOVE ME AFTER OCTOBER -->

--- a/flask_backend/templates/base.html
+++ b/flask_backend/templates/base.html
@@ -268,10 +268,7 @@
         (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl)
       );
     </script>
-    {% if request.path == url_for('screening.index') %}
-      <script data-goatcounter="https://cinemaempoa.goatcounter.com/count"
-      async src="//gc.zgo.at/count.js"></script>
-    {% endif %}
+    <script data-goatcounter="https://cinemaempoa.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 
     <!-- REMOVE ME AFTER OCTOBER -->
     <script src="{{ url_for('static', filename='halloween/bats.js') }}"></script>

--- a/flask_backend/templates/movie/movies.html
+++ b/flask_backend/templates/movie/movies.html
@@ -57,6 +57,17 @@
     )
 
     if (!nextPageFetch.ok) {
+      if (nextPageFetch.status && nextPageFetch.status == 404) {
+        // register that someone scrolled to the bottom of the page
+        // using a goatcounter event
+        if (window.goatcounter) {
+          window.goatcounter.count({
+            path: window.location.pathname,
+            title: "Posters loaded last page",
+            event: true,
+          });
+        }
+      }
       return;
     }
 
@@ -75,6 +86,15 @@
     const lastImage = imgsObserver[imgsObserver.length - 1];
     lastImage.setAttribute("data-observed", 1);
     _observer.observe(lastImage);
+    // register that someone scrolled up to the next page
+    // using a goatcounter event
+    if (window.goatcounter) {
+      window.goatcounter.count({
+        path: window.location.pathname,
+        title: "Posters load next page",
+        event: true,
+      });
+    }
   }
 
   function removeOnError(e) {

--- a/flask_backend/templates/screening/create.html
+++ b/flask_backend/templates/screening/create.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block header %}
-  <h1>{% block title %}Criar sessão{% endblock %}</h1>
+  <h1 data-goatcounter-skip="true">{% block title %}Criar sessão{% endblock %}</h1>
   <p></p>
 {% endblock %}
 

--- a/flask_backend/templates/screening/import.html
+++ b/flask_backend/templates/screening/import.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %} {% block header %}
-<h1>{% block title %}Importar sessões{% endblock %}</h1>
+<h1 data-goatcounter-skip="true">{% block title %}Importar sessões{% endblock %}</h1>
 <p></p>
 {% endblock %} {% block content %}
 <form method="post" enctype="multipart/form-data">

--- a/flask_backend/templates/screening/update.html
+++ b/flask_backend/templates/screening/update.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %} {% block header %}
-<h1>{% block title %}Editar "{{ screening.movie['title'] }}"{% endblock %}</h1>
+<h1 data-goatcounter-skip="true">{% block title %}Editar "{{ screening.movie['title'] }}"{% endblock %}</h1>
 {% endblock %} {% block content %}
 <p>No cinema <strong>{{screening.cinema.name}}</strong></p>
 <form method="post" enctype="multipart/form-data">


### PR DESCRIPTION
Resolve o #44 :

- Adiciona o analytics em todas as páginas;
- Permite desativar o analytics em páginas específicas adicionando `data-goatcounter-skip` em qualquer elemento da página (por padrão, botei sempre no `h1`);

Aproveitei pra adicionar alguns eventos customizados pra registrar as seguintes interações dos usuários no site:

- Carregamento de novas imagens na páginas dos posters
- Cliques no sketch de cubismo

Mais por curiosidade e pra entender melhor como o [goatcounter](https://www.goatcounter.com/) funciona. Já reparei que os eventos tem baixa fidelidade (nem todos são registrados, se o mesmo usuário enviar vários eventos em sequência só registra o primeiro, etc).