### PR TITLE
fix: first day of month not finding sessions

### DIFF
--- a/scrapers/paulo_amorim.py
+++ b/scrapers/paulo_amorim.py
@@ -164,7 +164,7 @@ class CinematecaPauloAmorim:
             strong_tag = p_tag.find("strong")
             if strong_tag is None:
                 continue
-            strong_text = unicodedata.normalize("NFKC", strong_tag.text)
+            strong_text = unicodedata.normalize("NFKC", strong_tag.text.replace("º", ""))
             movie_matches_today = strong_text.lower().startswith(
                 today_str
             ) or strong_text.lower().startswith(today_str_no_leading_zero)


### PR DESCRIPTION
## Descrição
Conforme indicado na issue #64, no primeiro dia do mês não era encontradas as sessões pois a data vinha como "1º de Maio", por exemplo. Para resolver esse problema, foi adicionado um replace na string da data removendo o "º' e substituindo por um espaço vazio, fazendo com que as sessões sejam encontradas corretamente

## Screenshots
Antes da modificação - Exemplo 25/10
![image](https://github.com/user-attachments/assets/f2b3600a-1f03-442e-a5fc-4e936f11deb6)

Após a modificação - Exemplo 25/10
![image](https://github.com/user-attachments/assets/08ab40aa-2564-41b0-ba90-962b3c3f8080)

## Teste 
Para testar a modificação, alterei manualmente o arquivo `grade.html`, adicionando o caractere especial na data: 
![image](https://github.com/user-attachments/assets/3cf0f309-2e51-4464-85c7-74744648cdb7)
