### PR TITLE
Adicionando tipos de usuário e tela de acesso negado

### DIFF
--- a/example.env
+++ b/example.env
@@ -3,5 +3,6 @@ SESSION_KEY=averyrandomandsecretivekey
 ACME_EMAIL=administrator@email.com # used to register the ssl certificate for https
 ADMIN_PROD_USERNAME=adminusername
 ADMIN_PROD_PWD=adminpassword
+ADMIN_PROD_ROLES=["USER","ADMIN"]
 IMGBB_API_KEY=imgbbapikey # api-key from https://api.imgbb.com/
 GEMINI_API_KEY=mygeminiapikey

--- a/flask_backend/db.py
+++ b/flask_backend/db.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 
-from flask_backend.env_config import ADMIN_PROD_PWD, ADMIN_PROD_USERNAME, DATABASE_URL
+from flask_backend.env_config import ADMIN_PROD_PWD, ADMIN_PROD_USERNAME, ADMIN_PROD_ROLES, DATABASE_URL
 
 engine = create_engine(DATABASE_URL)
 db_session = scoped_session(
@@ -26,7 +26,7 @@ def seed_db_prod():
     print("Setting up admin user")
     try:
         user_seeds.create_user_from_data(
-            db_session, ADMIN_PROD_USERNAME, ADMIN_PROD_PWD
+            db_session, ADMIN_PROD_USERNAME, ADMIN_PROD_PWD, ADMIN_PROD_ROLES
         )
     except IntegrityError:
         db_session.rollback()

--- a/flask_backend/env_config.py
+++ b/flask_backend/env_config.py
@@ -7,6 +7,7 @@ SESSION_KEY = config("SESSION_KEY", default="dev")
 APP_ENVIRONMENT = config("APP_ENVIRONMENT", default=EnvironmentEnum.DEVELOPMENT)
 ADMIN_PROD_USERNAME = config("ADMIN_PROD_USERNAME", default="cinemaempoa")
 ADMIN_PROD_PWD = config("ADMIN_PROD_PWD", default="secret-pwd")
+ADMIN_PROD_ROLES = config("ADMIN_PROD_ROLES", default=["USER","ADMIN"])
 UPLOAD_DIR = config("UPLOAD_DIR", None)
 IMGBB_API_KEY = config(
     "IMGBB_API_KEY", default="invalid-key"

--- a/flask_backend/models.py
+++ b/flask_backend/models.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String
+from sqlalchemy import JSON, Boolean, Column, Date, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, relationship
 
 from flask_backend.db import Base
@@ -9,9 +9,10 @@ from flask_backend.db import Base
 class User(Base):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True)
-    username = Column(String(20), unique=True, nullable=False)
-    password = Column(String, nullable=False)
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    username: Mapped[str] = Column(String(20), unique=True, nullable=False)
+    password: Mapped[str] = Column(String, nullable=False)
+    roles: Mapped[List[str]] = Column(JSON, nullable=False)
 
 
 class Movie(Base):

--- a/flask_backend/repository/users.py
+++ b/flask_backend/repository/users.py
@@ -12,8 +12,8 @@ def get_by_id(id: int) -> Optional[User]:
     return db_session.query(User).filter(User.id == id).first()
 
 
-def create(username: str, password: str) -> User:
-    user = User(username=username, password=password)
+def create(username: str, password: str, roles: list[str]) -> User:
+    user = User(username=username, password=password, roles=roles)
     db_session.add(user)
     db_session.commit()
     db_session.refresh(user)

--- a/flask_backend/routes/screening.py
+++ b/flask_backend/routes/screening.py
@@ -189,16 +189,19 @@ def create():
             valid_dates.append(f"{parsed_date.date()}T{str(parsed_date.time())[0:5]}")
         except ValueError:
             pass
-
-    return render_template(
-        "screening/create.html",
-        cinemas=cinemas,
-        current_date=current_date,
-        received_dates=valid_dates,
-        max_year=max_year,
-        max_file_size=current_app.config["MAX_CONTENT_LENGTH"],
-    )
-
+    if "ADMIN" in g.user.roles: 
+        return render_template(
+            "screening/create.html",
+            cinemas=cinemas,
+            current_date=current_date,
+            received_dates=valid_dates,
+            max_year=max_year,
+            max_file_size=current_app.config["MAX_CONTENT_LENGTH"],
+        )
+    else: 
+        return render_template(
+            "auth/forbidden.html",
+        )
 
 @bp.route("/screening/<int:id>/publish", methods=("POST",))
 @login_required
@@ -414,7 +417,13 @@ def import_screenings():
 
         flash(f"«{created_features}» sessões criadas com sucesso!", "success")
 
-    return render_template("screening/import.html", suggestions=suggestions)
+    if "ADMIN" in g.user.roles: 
+        return render_template("screening/import.html", suggestions=suggestions)
+    else: 
+        return render_template(
+            "auth/forbidden.html",
+        )
+    
 
 
 @bp.route("/screening/image/describe", methods=("POST",))

--- a/flask_backend/seeds/user_seeds.py
+++ b/flask_backend/seeds/user_seeds.py
@@ -5,11 +5,11 @@ from flask_backend.models import User
 
 def create_user(db_session):
     db_session.add(
-        User(username="cinemaempoa", password=generate_password_hash("123123"))
+        User(username="cinemaempoa", password=generate_password_hash("123123"), roles=["USER", "ADMIN"]), 
     )
     db_session.commit()
 
 
-def create_user_from_data(db_session, username, pwd):
-    db_session.add(User(username=username, password=generate_password_hash(pwd)))
+def create_user_from_data(db_session, username, pwd, roles):
+    db_session.add(User(username=username, password=generate_password_hash(pwd), roles=roles))
     db_session.commit()

--- a/flask_backend/templates/auth/forbidden.html
+++ b/flask_backend/templates/auth/forbidden.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="d-flex flex-column justify-content-center align-items-center"  style="height: 50vh; width: auto;">
+    <div class="d-flex flex-column align-items-center" >
+        <h1>
+            {% block title %}
+            Acesso Negado
+            {% endblock title %}
+        </h1>
+        <p>Você não tem as permissões necessárias para acessar esta página.</p>
+    </div>
+    <div class="alert alert-danger text-center" role="alert">
+        <h4 class="alert-heading">Acesso Negado</h4>
+        <p>Infelizmente, sua conta não possui as permissões exigidas para acessar esta área.</p>
+        <hr>
+        <p class="mb-0">Entre em contato com o administrador do sistema caso acredite que isto seja um erro.</p>
+    </div>
+</div>
+{% endblock content %}

--- a/flask_backend/templates/base.html
+++ b/flask_backend/templates/base.html
@@ -123,6 +123,7 @@
                         <a class="nav-link" href="{{ url_for("movie.index") }}">Filmes</a>
                     </li>
                     {% if g.user %}
+                        {% if g.user and "ADMIN" in g.user.roles%}
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for("screening.import_screenings") }}">Importar
                             sessões</a>
@@ -130,6 +131,7 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for("screening.create") }}">Nova sessão</a>
                         </li>
+                        {% endif %}
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for("auth.logout") }}">Sair</a>
                         </li>
@@ -154,6 +156,7 @@
                 </li>
                 <div class="vr mx-3"></div>
                 {% if g.user %}
+                    {% if g.user and "ADMINs" in g.user.roles%}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for("screening.import_screenings") }}">Importar sessões</a>
                     </li>
@@ -162,6 +165,7 @@
                         <a class="nav-link" href="{{ url_for("screening.create") }}">Nova sessão</a>
                     </li>
                     <div class="vr mx-3"></div>
+                    {% endif %}
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for("auth.logout") }}">Sair</a>
                     </li>

--- a/scrapers/paulo_amorim.py
+++ b/scrapers/paulo_amorim.py
@@ -164,7 +164,7 @@ class CinematecaPauloAmorim:
             strong_tag = p_tag.find("strong")
             if strong_tag is None:
                 continue
-            strong_text = unicodedata.normalize("NFKC", strong_tag.text)
+            strong_text = unicodedata.normalize("NFKC", strong_tag.text.replace("º", ""))
             movie_matches_today = strong_text.lower().startswith(
                 today_str
             ) or strong_text.lower().startswith(today_str_no_leading_zero)


### PR DESCRIPTION
# Descrição
Baseado no que foi pedido na issue #40, foi adicionado o atributo `roles` (sendo um array de strings) para a entidade `User`,  contendo as roles do usuário. Além disso, foi adicionado a renderização condicional dos itens  `Importar sessões` e `Nova sessão` do menu, sendo renderizados apenas se o usuário tiver a role `ADMIN`. Também foi adicionado uma tela para indicar ao usuário que ele não tem as permissões necessárias, caso acesse uma página via URL que não poderia.

# Prints
## Usuário com permissão de ADMIN
### Menu 
![image](https://github.com/user-attachments/assets/3daf0beb-7773-4b16-b8af-7c5af92d5a5f)
### Menu mobile
![image](https://github.com/user-attachments/assets/3f27a879-5b81-4bf8-8b42-9517198a3fb1)
### Acesso à `screening/new`
![image](https://github.com/user-attachments/assets/7b9fe263-fb8b-4a13-be07-3908f7eee1d8)
### Acesso à `screening/import`
![image](https://github.com/user-attachments/assets/0a6d83c7-397d-42a4-9d70-44ba797cab5b)


## Usuário sem permissão de ADMIN
### Menu
![image](https://github.com/user-attachments/assets/05895334-5173-480c-9714-8cd449db9de2)
### Menu mobile
![image](https://github.com/user-attachments/assets/f9c64a43-5790-405a-8fda-78a7be8c9ddf)
### Acesso à `screening/new`
![image](https://github.com/user-attachments/assets/d4c87cfd-6d11-4147-8f1e-5e96ea1fc255)
### Acesso à `screening/import`
![image](https://github.com/user-attachments/assets/63e79585-52cc-46bc-8e77-d08722d41b01)

## Usuário não autenticado
### Menu
![image](https://github.com/user-attachments/assets/b3a26696-32b5-4071-877d-1a9b82e7fc59)
### Menu mobile
![image](https://github.com/user-attachments/assets/19880cc5-8b40-4d57-a861-1c9f89f89f9d)



closes #40 