### PR TITLE
Adapts Sala Redenção scrapper for new landing page format

### DIFF
--- a/scrapers/sala_redencao.py
+++ b/scrapers/sala_redencao.py
@@ -51,13 +51,14 @@ class SalaRedencao:
 
     def _get_events_blog_post_url(self):
         landing_page_soup = BeautifulSoup(self._get_landing_page_html(), "html.parser")
-        events_post_anchor_tag = landing_page_soup.css.select(
-            "a.evcal_evdata_row.evo_clik_row"
+        full_post_links = landing_page_soup.css.select(
+            ".full-post-link"
         )
-        for event_post_anchor_tag in events_post_anchor_tag:
-            event_inner_url = event_post_anchor_tag["href"]
-            if event_inner_url and event_inner_url not in self.events:
-                self.events.append(event_inner_url)
+        for full_post_link in full_post_links:
+            event_url = full_post_link["href"]
+            if event_url and event_url not in self.events:
+                self.events.append(event_url)
+        return self.events
 
     def _parse_blog_post_with_regex(self, event_soup, event_url):
         event_content_inner = event_soup.css.select_one("div.content-inner")

--- a/scrapers/sala_redencao.py
+++ b/scrapers/sala_redencao.py
@@ -117,13 +117,27 @@ class SalaRedencao:
         content_inner = blog_post_soup.find("div", class_="content-inner")
         p_tags = content_inner.find_all("p")
         feats = []
-        pattern = r"([\w\s]+)\(dir\. ([\w\s]+) \| ([\w\s]+) \| (\d{4}) \| (\d+ min)\)(.*?)((?:\d{1,2} de [a-z]+ \| [\w\-]+ \| \d{1,2}[hH]\s*)+)"
+        pattern = r"([\w\s]+)\([Dd]ir\. ([\w\s]+) \| ([\w\s]+) \| (\d{4}) \| (\d+ min)"
         for p_tag in p_tags:
             matches = re.findall(pattern, p_tag.text, re.DOTALL)
             for movie in matches:
                 screening_dates = re.findall(
-                    r"(\d{1,2} de [a-z]+ \| [\w\-]+ \| \d{1,2}[hH])", movie[6]
+                    r"(\d{1,2} de [a-z]+ \| [\w\-]+ \| \d{1,2}[hH])", p_tag.text
                 )
+                if len(screening_dates) == 0:
+                    continue
+
+                # find the index of the first matching group from `movie`
+                excerpt_start = p_tag.text.find(movie[4])
+                # find the index of the first screening date
+                excerpt_end = p_tag.text.find(screening_dates[0])
+
+                # Consider the text between the `movie` and the `screening_dates`
+                # as the excerpt. Include the `movie` in the excerpt to avoid complex parsing.
+                excerpt = p_tag.text[excerpt_start:excerpt_end]
+                excerpt = movie[4] + " " + excerpt
+                excerpt = excerpt.strip()
+
                 time = []
                 for date in screening_dates:
                     if not string_is_day(date, self.date):
@@ -139,7 +153,6 @@ class SalaRedencao:
                 countries = movie[2].strip()
                 year = movie[3]
                 duration = movie[4].strip()
-                excerpt = movie[5].strip()
 
                 feature = {
                     "poster": "",


### PR DESCRIPTION
This PR attempts to fix the redenção scrapper for the latest changes in the https://www.ufrgs.br/difusaocultural/salaredencao/ website html format.

We are still going through each of the _Notícias_ linked in the landing page and using regexp to parse possible movie dates from each notícia.

I've managed to simplify the regexp a bit so it might prove itself more flexible