### PR TITLE
Add poster download option

### DIFF
--- a/flask_backend/repository/movies.py
+++ b/flask_backend/repository/movies.py
@@ -34,6 +34,21 @@ def get_paginated(
     return query.all()
 
 
+def get_paginated_with_images(
+    current_page: int, per_page: int, include_drafts: bool = False
+) -> List[Optional[Movie]]:
+    offset_value = (current_page - 1) * per_page
+
+    query = db_session.query(Screening).filter(Screening.image.isnot(None)).order_by(Screening.id.desc())
+
+    if not include_drafts:
+        query = query.filter(Screening.draft == False)  # noqa: E712
+
+    query = query.limit(per_page).offset(offset_value)
+
+    return query.all()
+
+
 def get_by_title(title: str) -> Optional[Movie]:
     return db_session.query(Movie).filter(Movie.title == title).first()
 

--- a/flask_backend/repository/screenings.py
+++ b/flask_backend/repository/screenings.py
@@ -111,3 +111,7 @@ def delete(
         db_session.delete(_date)
     db_session.delete(screening)
     db_session.commit()
+
+
+def get_screening_by_image_filename(filename: str) -> Optional[Screening]:
+    return db_session.query(Screening).filter(Screening.image.endswith(filename)).first()

--- a/flask_backend/routes/movie.py
+++ b/flask_backend/routes/movie.py
@@ -1,12 +1,14 @@
 import math
-
-from flask import Blueprint, g, jsonify, render_template, request
+import os
+import mimetypes
+from flask import Blueprint, g, jsonify, render_template, request, send_file, current_app
 from werkzeug.exceptions import abort
 
 from flask_backend.repository.movies import (
     get_all as get_all_movies,
     get_movies_with_similar_titles,
     get_paginated,
+    get_paginated_with_images,
 )
 from flask_backend.routes.auth import login_required
 
@@ -50,7 +52,7 @@ def poster_images():
         abort(400)
 
     user_logged_in = g.user is not None
-    screenings_list = get_paginated(page, limit, user_logged_in)
+    screenings_list = get_paginated_with_images(page, limit, user_logged_in)
 
     if len(screenings_list) == 0:
         abort(404)
@@ -59,23 +61,29 @@ def poster_images():
     images = []
     image_urls = set()
     for screening in screenings_list:
-        if not screening.image:
-            continue
         if screening.image in image_urls:
             continue
 
         image_urls.add(screening.image)
-        if screening.image:
-            images.append(
-                {
-                    "screening_id": screening.id,
-                    "url": screening.image,
-                    "width": imgDisplayWidth,
-                    "height": math.ceil(
-                        imgDisplayWidth / screening.image_width * screening.image_height
-                    ),
-                }
-            )
+        filename = screening.image.split('/')[-1]
+        movie_title = screening.movie.title
+        safe_title = "".join(c for c in movie_title if c.isalnum() or c in (' ', '-', '_')).rstrip()
+        safe_title = safe_title.replace(' ', '_')
+        file_extension = os.path.splitext(filename)[1]
+        download_name = f"{safe_title}{file_extension}"
+        
+        images.append(
+            {
+                "screening_id": screening.id,
+                "url": screening.image,
+                "filename": filename,
+                "download_name": download_name,
+                "width": imgDisplayWidth,
+                "height": math.ceil(
+                    imgDisplayWidth / screening.image_width * screening.image_height
+                ),
+            }
+        )
     return render_template(
         "movie/movie_posters.html", images=images, show_drafts=user_logged_in
     )
@@ -91,15 +99,13 @@ def poster_images_urls():
         abort(400)
 
     user_logged_in = g.user is not None
-    screenings_list = get_paginated(page, limit, user_logged_in)
+    screenings_list = get_paginated_with_images(page, limit, user_logged_in)
 
     if len(screenings_list) == 0:
         abort(404)
 
     image_urls = []
     for screening in screenings_list:
-        if not screening.image:
-            continue
         if screening.image in image_urls:
             continue
         image_urls.append(screening.image)
@@ -112,3 +118,39 @@ def search_movies():
     title = request.args.get("title")
     movies = get_movies_with_similar_titles(title)
     return jsonify([{"title": movie.title} for movie in movies])
+
+
+@bp.route("/movies/posters/download/<filename>")
+def download_poster(filename):
+    try:
+        file_path = os.path.join(current_app.config["UPLOAD_FOLDER"], filename)
+        
+        if not os.path.exists(file_path):
+            abort(404)
+        
+        mimetype, _ = mimetypes.guess_type(file_path)
+        if mimetype is None:
+            mimetype = 'application/octet-stream'
+        
+        from flask_backend.repository.screenings import get_screening_by_image_filename
+        screening = get_screening_by_image_filename(filename)
+        
+        if screening:
+            movie_title = screening.movie.title
+            safe_title = "".join(c for c in movie_title if c.isalnum() or c in (' ', '-', '_')).rstrip()
+            safe_title = safe_title.replace(' ', '_')
+            file_extension = os.path.splitext(filename)[1]
+            download_name = f"{safe_title}{file_extension}"
+        else:
+            file_extension = os.path.splitext(filename)[1]
+            download_name = f"poster{file_extension}"
+        
+        return send_file(
+            file_path,
+            as_attachment=True,
+            download_name=download_name,
+            mimetype=mimetype
+        )
+    except Exception as e:
+        current_app.logger.error(f"Erro ao fazer download do poster {filename}: {str(e)}")
+        abort(500)

--- a/flask_backend/templates/movie/movie_posters.html
+++ b/flask_backend/templates/movie/movie_posters.html
@@ -1,9 +1,22 @@
 {% for image in images %}
-    <img data-screening-id="{{ image['screening_id'] }}"
-         class="grid-item"
-         src="{{ image['url'] }}"
-         width="325"
-         height="{{ image['height'] }}"
-         onerror="removeOnError(event)"
-         {% if image['image_alt'] %}alt="{{ image['image_alt'] }}"{% endif %} />
+    <div class="poster-container grid-item" data-screening-id="{{ image['screening_id'] }}">
+        <img src="{{ image['url'] }}"
+             width="325"
+             height="{{ image['height'] }}"
+             onerror="removeOnError(event)"
+             {% if image['image_alt'] %}alt="{{ image['image_alt'] }}"{% endif %} />
+        <div class="download-overlay" style="position: absolute !important; bottom: 10px !important; right: 3px !important; left: auto !important;">
+            <a href="{{ url_for('movie.download_poster', filename=image['filename']) }}" 
+               class="download-btn" 
+               title="Baixar poster"
+               download="{{ image['download_name'] }}"
+               style="color: white !important; text-shadow: 0 0 5px rgba(0, 0, 0, 1), 0 0 5px rgba(0, 0, 0, 1), 0 0 5px rgba(0, 0, 0, 1), 0 0 5px rgba(0, 0, 0, 1), 0 0 5px rgba(0, 0, 0, 1), 0 2px 6px rgba(0, 0, 0, 0.9);">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M21 15V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M7 10L12 15L17 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 15V3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </a>
+        </div>
+    </div>
 {% endfor %}

--- a/flask_backend/templates/movie/movies.html
+++ b/flask_backend/templates/movie/movies.html
@@ -3,6 +3,71 @@
     .grid-item {
         width: 325px;
     }
+    
+    .poster-container {
+        position: relative;
+        display: inline-block;
+        cursor: pointer;
+        width: 325px;
+        overflow: visible;
+        line-height: 0;
+    }
+    
+    .poster-container img {
+        width: 100%;
+        height: auto;
+        display: block;
+        vertical-align: top;
+    }
+    
+    .download-overlay {
+        position: absolute !important;
+        bottom: 10px !important;
+        right: 3px !important;
+        left: auto !important;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        background: rgba(255, 255, 255, 0.95) !important;
+        border-radius: 50%;
+        width: 44px;
+        height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+        pointer-events: auto;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        border: 2px solid rgba(255, 255, 255, 0.9);
+        transform: translateX(0);
+    }
+    
+    .poster-container:hover .download-overlay {
+        opacity: 1;
+    }
+    
+    .download-btn {
+        color: #333 !important;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        transition: all 0.2s ease;
+    }
+    
+    .download-btn:hover {
+        color: #007bff;
+        background: rgba(0, 0, 0, 0.1);
+        transform: scale(1.1);
+    }
+    
+    .download-btn svg {
+        width: 28px;
+        height: 28px;
+        filter: drop-shadow(0 0 4px rgba(0, 0, 0, 1)) drop-shadow(0 0 4px rgba(0, 0, 0, 1)) drop-shadow(0 0 4px rgba(0, 0, 0, 1)) drop-shadow(0 0 4px rgba(0, 0, 0, 1)) drop-shadow(0 0 4px rgba(0, 0, 0, 1)) drop-shadow(0 2px 6px rgba(0, 0, 0, 0.9));
+    }
 </style>
 {% block header %}
     <h1>
@@ -30,7 +95,7 @@
         {% include "movie/movie_posters.html" %}
     </section>
     <script>
-        let masonry, observer, currPage = 0;
+        let masonry, observer, currPage = -1;
 
         async function intersectionCallback(entries, _observer) {
             const entry = entries[0];
@@ -73,16 +138,16 @@
             const nextPageText = await nextPageFetch.text();
             const parser = new DOMParser();
             const doc = parser.parseFromString(nextPageText, 'text/html');
-            const nextPageImages = doc.querySelectorAll("img.grid-item");
+            const nextPageContainers = doc.querySelectorAll(".poster-container.grid-item");
 
             section.setAttribute('data-page', nextPage);
-            nextPageImages.forEach((img) => section.appendChild(img));
-            masonry.appended(nextPageImages);
+            nextPageContainers.forEach((container) => section.appendChild(container));
+            masonry.appended(nextPageContainers);
 
-            const imgsObserver = Array.from(section.getElementsByTagName('img'));
-            const lastImage = imgsObserver[imgsObserver.length - 1];
-            lastImage.setAttribute("data-observed", 1);
-            _observer.observe(lastImage);
+            const containersObserver = Array.from(section.getElementsByClassName('poster-container'));
+            const lastContainer = containersObserver[containersObserver.length - 1];
+            lastContainer.setAttribute("data-observed", 1);
+            _observer.observe(lastContainer);
             // register that someone scrolled up to the next page
             // using a goatcounter event
             if (window.goatcounter) {
@@ -96,13 +161,14 @@
 
         function removeOnError(e) {
             const img = e.target;
-            const isObserved = img.getAttribute("data-observed");
-            img.remove();
+            const container = img.closest('.poster-container');
+            const isObserved = container.getAttribute("data-observed");
+            container.remove();
             if (isObserved) {
-                const imgs = Array.from(document.querySelectorAll("section.grid img.grid-item"));
-                const lastImage = imgs[imgs.length - 1];
-                observer.observe(lastImage);
-                lastImage.setAttribute("data-observed", 1);
+                const containers = Array.from(document.querySelectorAll("section.grid .poster-container"));
+                const lastContainer = containers[containers.length - 1];
+                observer.observe(lastContainer);
+                lastContainer.setAttribute("data-observed", 1);
             }
             masonry.layout();
         }
@@ -128,11 +194,11 @@
             const nextPageText = await nextPageFetch.text();
             const parser = new DOMParser();
             const doc = parser.parseFromString(nextPageText, 'text/html');
-            const nextPageImages = doc.querySelectorAll("img.grid-item");
+            const nextPageContainers = doc.querySelectorAll(".poster-container.grid-item");
 
             section.setAttribute('data-page', nextPage);
-            nextPageImages.forEach((img) => section.appendChild(img));
-            masonry.appended(nextPageImages);
+            nextPageContainers.forEach((container) => section.appendChild(container));
+            masonry.appended(nextPageContainers);
         }
 
         document.addEventListener("DOMContentLoaded", async (event) => {
@@ -152,8 +218,10 @@
             observer = new IntersectionObserver(intersectionCallback, {
                 threshold: 1
             });
-            const imgs = Array.from(document.querySelectorAll(".grid-item"));
-            observer.observe(imgs[imgs.length - 1]);
+            const containers = Array.from(document.querySelectorAll(".poster-container.grid-item"));
+            if (containers.length > 0) {
+                observer.observe(containers[containers.length - 1]);
+            }
         });
     </script>
     <script src="{{ url_for('static', filename='imagesLoaded.js') }}"></script>


### PR DESCRIPTION
### **Funcionalidade: Botão de Download de Posters**

**Implementação de sistema de download de posters na página de posters do cinemaempoa, permitindo aos usuários baixar posters individuais com nomes baseados no título do filme.**

#### **🔧 Principais Mudanças:**

**1. Nova Rota de Download**
- Adicionada rota `/movies/posters/download/<filename>` para download individual de posters
- Suporte a diferentes tipos de imagem (PNG, JPG, etc.)
- Nomes de arquivo inteligentes baseados no título do filme

**2. Interface Visual Atualizada**
- Botão de download com ícone SVG no canto inferior direito dos posters
- Aparece no hover com contorno preto forte para visibilidade em qualquer poster
- Posicionamento responsivo e elegante

**3. Sistema de Busca Otimizado**
- Nova função `get_paginated_with_images()` que retorna apenas screenings com imagens
- Melhoria na performance e carregamento de dados
- Correção do modo cubismo que não estava carregando imagens

**4. Nomes de Arquivo Inteligentes**
- Ex: `VERMIGLIO_A_NOIVA_DA_MONTANHA.png`
- Limpeza automática de caracteres especiais
- Fallback seguro para casos de erro

#### **📁 Arquivos Modificados:**
- `flask_backend/routes/movie.py` - Nova rota de download e otimizações
- `flask_backend/repository/movies.py` - Nova função de busca com imagens
- `flask_backend/repository/screenings.py` - Função auxiliar para busca por imagem
- `flask_backend/templates/movie/movie_posters.html` - Template com botão de download
- `flask_backend/templates/movie/movies.html` - CSS para estilização do botão

#### **Benefícios:**
- Usuários podem baixar posters diretamente da página
- Nomes de arquivo organizados e identificáveis
- Interface intuitiva e responsiva
- Correção do modo cubismo que estava quebrado

---

<img width="1851" height="966" alt="image" src="https://github.com/user-attachments/assets/2bd933ae-3ecc-41d6-acd8-a4903570e98f" />
