### PR TITLE
Adds command to merge duplicated movies based on slug

### DIFF
--- a/flask_backend/commands.py
+++ b/flask_backend/commands.py
@@ -6,11 +6,15 @@ from flask import current_app
 from flask_backend.repository.cinemas import (
     get_by_slug as get_cinema_by_slug,
 )
+from flask_backend.scripts.dedupper import dedupper
+from flask_backend.scripts.dupechecker import dupe_checker
 from flask_backend.service.runner import Runner
 
 
 def register_commands(app):
     app.cli.add_command(import_json)
+    app.cli.add_command(dupe_check)
+    app.cli.add_command(run_dedupper)
 
 
 @click.command("import-json")
@@ -40,3 +44,13 @@ def import_json(json_path):
     # all validations passed, import screenings :)
     created_features = runner.import_scrapped_results(current_app)
     click.echo(f"«{created_features}» sessões criadas com sucesso!")
+
+
+@click.command("dupe-check")
+def dupe_check():
+    dupe_checker()
+
+
+@click.command("run-dedupper")
+def run_dedupper():
+    dedupper()

--- a/flask_backend/repository/movies.py
+++ b/flask_backend/repository/movies.py
@@ -74,3 +74,14 @@ def get_movies_with_similar_titles(title: str) -> List[Movie]:
     return (
         db_session.query(Movie).filter(Movie.title.ilike(f"%{title}%")).limit(3).all()
     )
+
+
+def delete(movie: Movie) -> None:
+    # delete all related screenings to maintain integrity
+    for _scr in movie.screenings:
+        # delete all related dates
+        for _dt in _scr.dates:
+            db_session.delete(_dt)
+        db_session.delete(_scr)
+    db_session.delete(movie)
+    db_session.commit()

--- a/flask_backend/scripts/dedupper.py
+++ b/flask_backend/scripts/dedupper.py
@@ -1,0 +1,91 @@
+from typing import List, Tuple
+
+from sqlalchemy import func
+
+from flask_backend.db import db_session
+from flask_backend.models import Movie, Screening
+from flask_backend.repository.movies import delete as delete_movie
+from flask_backend.repository.screenings import (
+    create as create_screening,
+    delete as delete_screening,
+    get_by_movie_id_and_cinema_id as get_screening_by_movie_id_and_cinema_id,
+    update_screening_dates,
+)
+from flask_backend.service.screening import build_dates
+
+
+def dedupper():
+    # gets all duplicated movies based on generated slug
+    dupped_movies: List[Tuple[str, str]] = (
+        db_session.query(Movie.slug, func.group_concat(Movie.id))
+        .group_by(Movie.slug)
+        .having(func.count(Movie.slug) > 1)
+        .all()
+    )
+
+    for slug, ids_str in dupped_movies:
+        ids = ids_str.split(",")
+        movies = (
+            db_session.query(Movie)
+            .join(Screening)
+            .filter(Movie.id.in_(ids))
+            .order_by(Movie.id)
+            .all()
+        )
+
+        # Keeps the oldest record
+        resulting_movie = movies[0]
+        print(f"Keeping movie id {resulting_movie.id} for {slug}")
+
+        for idx, movie in enumerate(movies):
+            if idx == 0:
+                continue
+            for screening in movie.screenings:
+                # checks if cinema already has screening for the movie we kept
+                screening_exists = get_screening_by_movie_id_and_cinema_id(
+                    resulting_movie.id, screening.cinema.id
+                )
+                if not screening_exists:
+                    # if the screening doesnt exist, copy it over and delete the original
+                    create_screening(
+                        movie_id=resulting_movie.id,
+                        cinema_id=screening.cinema_id,
+                        url_origin=screening.url,
+                        image=screening.image,
+                        image_alt=screening.image_alt,
+                        description=screening.description,
+                        is_draft=screening.draft,
+                        image_width=screening.image_width,
+                        image_height=screening.image_height,
+                        screening_dates=build_dates(
+                            [f"{sd.date}T{sd.time}" for sd in screening.dates]
+                        ),
+                    )
+                    delete_screening(screening)
+                    continue
+                # screening already exists. we need to copy the dates over
+                existing_dates = build_dates(
+                    [f"{sd.date}T{sd.time}" for sd in screening_exists.dates]
+                )
+                screening_dates = build_dates(
+                    [f"{sd.date}T{sd.time}" for sd in screening.dates]
+                )
+                for new_date in screening_dates:
+                    already_registered = False
+                    for existing_date in existing_dates:
+                        same_date = existing_date.date == new_date.date
+                        same_time = existing_date.time == new_date.time
+                        if same_date and same_time:
+                            already_registered = True
+                            break
+                    if not already_registered:
+                        existing_dates.append(new_date)
+                # deletes the original screening since we already copied the necessary dates
+                delete_screening(screening)
+                # adds the copied dates to the existing screening
+                update_screening_dates(screening_exists, existing_dates)
+            # removes the duplicated movie
+            assert (
+                len(movie.screenings) == 0
+            ), "There should be no screenings left at this point"
+            delete_movie(movie)

--- a/flask_backend/scripts/dupechecker.py
+++ b/flask_backend/scripts/dupechecker.py
@@ -1,0 +1,56 @@
+"""Finds duplicated movies based on the `slug` field. Returns a list of duplicated movies and their screenings on each cinema."""
+
+from datetime import datetime
+
+from sqlalchemy import func
+
+from flask_backend.db import db_session
+from flask_backend.models import Movie, Screening
+from utils import dump_utf8_json
+
+
+def dupe_checker():
+    dupped_movies = (
+        db_session.query(
+            Movie.slug, func.group_concat(Movie.id), func.group_concat(Movie.title)
+        )
+        .group_by(Movie.slug)
+        .having(func.count(Movie.slug) > 1)
+    )
+
+    dupped_info = []
+    for slug, ids_str, titles_str in dupped_movies:
+        dupped_movie = {
+            "slug": slug,
+            "movie_ids": ids_str,
+            "movie_titles": titles_str,
+            "cinemas": {},
+        }
+        ids = ids_str.split(",")
+        movies = db_session.query(Movie).filter(Movie.id.in_(ids)).all()
+        for movie in movies:
+            screenings = (
+                db_session.query(Screening).filter(Screening.movie_id == movie.id).all()
+            )
+            for screening in screenings:
+                cinema = screening.cinema.slug
+                if cinema not in dupped_movie["cinemas"]:
+                    dupped_movie["cinemas"][cinema] = {"dates": set(), "images": set()}
+                dupped_movie["cinemas"][cinema]["images"].add(screening.image)
+                for _date in screening.dates:
+                    dupped_movie["cinemas"][cinema]["dates"].add(
+                        f"{_date.date}T{_date.time}"
+                    )
+        dupped_info.append(dupped_movie)
+
+    for dupped_movie in dupped_info:
+        for cin in dupped_movie["cinemas"].keys():
+            dupped_movie["cinemas"][cin]["images"] = list(
+                dupped_movie["cinemas"][cin]["images"]
+            )
+            dupped_movie["cinemas"][cin]["dates"] = sorted(
+                list(dupped_movie["cinemas"][cin]["dates"]),
+                key=lambda x: datetime.strptime(x, "%Y-%m-%dT%H:%M"),
+            )
+
+    print(dump_utf8_json(dupped_info))

--- a/flask_backend/templates/movie/index.html
+++ b/flask_backend/templates/movie/index.html
@@ -21,6 +21,7 @@
                                     <img loading="lazy"
                                          src="{{ movie.screenings[0].image }}"
                                          class="img-fluid rounded"
+                                         style="max-height: 75px; display:block; overflow: hidden;"
                                          alt="{{ movie.screenings[0].image_alt }}">
                                 {% else %}
                                     <img loading="lazy"


### PR DESCRIPTION
Fix #42 .

Com a implementação do campo `slug` em #152 a criação de novos filmes faz a busca no banco baseada no slug, o que impede repetições comuns quando o mesmo filme aparece com acentuação, capitalização ou espaçamentos diferentes.

Isso funciona tanto na criação manual de filmes (através das sessões em <https://cinemaempoa.com.br/screening/new>) quanto na importação dos .json (via comando ou em <https://cinemaempoa.com.br/screening/import>).

Existem outros problemas de duplicação, como o descrito em #65, mas vão ser resolvido em um próximo momento.

Esse PR  implementa um script que pode ser usado pra verificar se existem filmes duplicados (`flask --app flask_backend dupe-check`) e outro que faz o merge dos filmes duplicados, mantendo as sessões e os horários de exibição (`flask --app flask_backend run-dedupper`).

Idealmente esses scripts só vão precisar ser rodados uma única vez, mas optei por versionar eles pra servirem de referência na criação de testes no futuro, ou algo assim.