### PR TITLE
Melhorias na lógica do Google Calendar

### DIFF
--- a/tests/scrapers/test_sala_redencao.py
+++ b/tests/scrapers/test_sala_redencao.py
@@ -56,6 +56,24 @@ class TestSalaRedencao(unittest.TestCase):
         assert len(features_overall) == len(features_gcal)
         assert features_overall == features_gcal
 
+    def test__parse_google_calendar_events_when_traditional_technique_works(self):
+        sala_redencao = SalaRedencao("2025-09-11")
+        gcal = sala_redencao._fetch_google_calendar()
+        features_gcal = sala_redencao._parse_google_calendar_events(gcal)
+        sala_redencao._get_events_blog_post_url()
+        features_traditional = sala_redencao._get_events_blog_post_html()
+        features_overall = sala_redencao.get_daily_features_json()
+
+        print(f"Features (gcal): {features_gcal}")
+        print(f"Features (traditional): {features_traditional}")
+        print(f"Features (overall): {features_overall}")
+
+        assert len(features_traditional) > 0
+        assert len(features_gcal) > 0
+        assert len(features_overall) == len(features_gcal)
+        assert len(features_overall) == len(features_traditional)
+        assert features_overall == features_traditional
+
     def test_get_daily_features_json(self):
         salaRedencao = SalaRedencao(date="2025-09-02")
         features = salaRedencao.get_daily_features_json()

--- a/tests/scrapers/test_sala_redencao.py
+++ b/tests/scrapers/test_sala_redencao.py
@@ -55,3 +55,12 @@ class TestSalaRedencao(unittest.TestCase):
         assert len(features_gcal) > 0
         assert len(features_overall) == len(features_gcal)
         assert features_overall == features_gcal
+
+    def test_get_daily_features_json(self):
+        salaRedencao = SalaRedencao(date="2025-09-02")
+        features = salaRedencao.get_daily_features_json()
+        assert len(features) == 3
+        titles = [f["title"] for f in features]
+        self.assertIn("Nu entre lobos", titles)
+        self.assertIn("Lissy", titles)
+        self.assertIn("Estrelas", titles)


### PR DESCRIPTION
Fix #161 

**Melhorias na lógica do Google Calendar para Sala Redenção**

De acordo com o feedback na PR #159 , estou fazendo algumas alterações:

- Checagem da data do evento obtido pelo link do Google Calendar no início do for loop, a fim de evitar rodar a lógica para todos os eventos do calendário
- Checagem do tipo de evento a fim de pular eventos de dia inteiro, sem hora de início. O calendário mostra a reserva para algumas reuniões internas da Sala, que não são relevantes.
- Diminuir dependência de regex para data e hora, utilizando a hora de início do campo DTSTART. O regex ainda é utilizado, mas apenas para filtrar a parte de datas do 'excerpt' com a sinopse.
- Novos testes unitários para validar que o método do Google Calendar não está sobrescrevendo os originais, e que atua apenas quando necessário

Fico à disposição para quaisquer dúvidas. 

**Restrições**

Eu não consegui utilizar o comando de seed-db localmente, e por isso não consegui testar os dados passados para o 'time' na página. Vou criar uma issue para informar do meu erro e entender se é algum engano meu ou não. 