### PR TITLE
182 - Adiciona layout pra pag-nav com suporte a varias paginas pra desktop e mobile

### DIFF
--- a/flask_backend/templates/movie/index.html
+++ b/flask_backend/templates/movie/index.html
@@ -84,20 +84,46 @@
         {% endfor %}
     </ul>
     <nav aria-label="Navegação das páginas de filmes">
-        <ul class="pagination">
+        <ul class="pagination justify-content-center">
             <li class="page-item {{ '' if prev_page else 'disabled' }}">
                 <a class="page-link"
-                   href="?{{ 'movie={}&'.format(movie) if movie }}page={{ prev_page }}&limit={{ limit }}">Anterior</a>
+                   href="?{{ 'movie={}&'.format(movie) if movie }}page={{ prev_page }}&limit={{ limit }}">
+                    <span class="d-none d-sm-inline">Anterior</span>
+                    <span class="d-inline d-sm-none">«</span>
+                </a>
             </li>
             {% for page in range(1, pages + 1) %}
-                <li class="page-item {{ 'active' if curr_page == page }}">
-                    <a class="page-link"
-                       href="?{{ 'movie={}&'.format(movie) if movie }}page={{ page }}&limit={{ limit }}">{{ page }}</a>
-                </li>
+                {% if page == 1 or page == pages %}
+                    <li class="page-item {{ 'active' if curr_page == page }}">
+                        <a class="page-link"
+                           href="?{{ 'movie={}&'.format(movie) if movie }}page={{ page }}&limit={{ limit }}">{{ page }}</a>
+                    </li>
+                {% elif page == curr_page - 1 or page == curr_page + 1 %}
+                    <li class="page-item">
+                        <a class="page-link"
+                           href="?{{ 'movie={}&'.format(movie) if movie }}page={{ page }}&limit={{ limit }}">{{ page }}</a>
+                    </li>
+                {% elif page == curr_page %}
+                    <li class="page-item active">
+                        <span class="page-link">{{ page }}</span>
+                    </li>
+                {% elif page == curr_page - 2 or page == curr_page + 2 %}
+                    <li class="page-item d-none d-sm-inline-block">
+                        <a class="page-link"
+                           href="?{{ 'movie={}&'.format(movie) if movie }}page={{ page }}&limit={{ limit }}">{{ page }}</a>
+                    </li>
+                {% elif page == curr_page - 3 or page == curr_page + 3 %}
+                    <li class="page-item disabled">
+                        <span class="page-link">...</span>
+                    </li>
+                {% endif %}
             {% endfor %}
             <li class="page-item {{ '' if next_page else 'disabled' }}">
                 <a class="page-link"
-                   href="?{{ 'movie={}&'.format(movie) if movie }}page={{ next_page }}&limit={{ limit }}">Próximo</a>
+                   href="?{{ 'movie={}&'.format(movie) if movie }}page={{ next_page }}&limit={{ limit }}">
+                    <span class="d-none d-sm-inline">Próximo</span>
+                    <span class="d-inline d-sm-none">»</span>
+                </a>
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
## Altera o layout da pagination nav pra suportar varias paginas

- desktop: page ativa + 2 neighbors de cada lado
- mobile: page ativa + 1 neighbor de cada lado e altera os botoes next/previous pra evitar line wrapping

desktop:
<img width="571" height="333" alt="image" src="https://github.com/user-attachments/assets/fc552db4-4499-41b4-9a60-2f6c1e89e0ec" />

mobile:
<img width="381" height="333" alt="image" src="https://github.com/user-attachments/assets/c7abeffe-d4de-4175-b5eb-47e6cf498654" />
