### PR TITLE
refector: remove column from distinct

### DIFF
--- a/flask_backend/repository/movies.py
+++ b/flask_backend/repository/movies.py
@@ -32,7 +32,7 @@ def get_all_paginated(
     offset_value = (current_page - 1) * per_page
     # includes the `distinct` clause both on the select and the count queries
     # to avoid mismatches on pagination
-    query = db_session.query(Movie).join(Screening).distinct(Movie.id)
+    query = db_session.query(Movie).join(Screening).distinct()
 
     if include_drafts is False:
         query = query.filter(Screening.draft == False)  # noqa: E712


### PR DESCRIPTION
### Descrição
O uso do distinct com a declaração de coluna é usado no SQL como DISTINCT ON (column_name), que apenas funciona no PostgreSQL e o uso em outros databases gerará CompileError como destacado na documentação. [Ref](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.distinct:~:text=Deprecated%20since%20version%201.4%3A%20Using%20*expr%20in%20other%20dialects%20is%20deprecated%20and%20will%20raise%20CompileError%20in%20a%20future%20version.)

Portanto foi removido a declaração da coluna no distinct().

### Contribuições checklist
 - [x] ruff: linter para código python e formatter para código python
 - [x] djlint: linter para os arquivos .html e formatter para os arquivos .html

### Issue
resolves #204 