### PR TITLE
fix: show multiple poster columns on mobile masonry grid

### DIFF
--- a/flask_backend/templates/movie/posters.html
+++ b/flask_backend/templates/movie/posters.html
@@ -2,12 +2,31 @@
 {% block meta_tags %}
     <meta name="description"
           content="Acesse o mosaico com todos os posters dos filmes cadastrados no site.">
+    <style>
+        .grid-sizer,
+        .grid-item {
+            width: 33.333%;
+        }
+
+        .grid-item {
+            height: auto;
+        }
+
+        @media (min-width: 400px) {
+            .grid-sizer,
+            .grid-item {
+                width: 25%;
+            }
+        }
+
+        @media (min-width: 700px) {
+            .grid-sizer,
+            .grid-item {
+                width: 325px;
+            }
+        }
+    </style>
 {% endblock meta_tags %}
-<style>
-    .grid-item {
-        width: 325px;
-    }
-</style>
 {% block header %}
     <h1>
         {% block title %}
@@ -31,6 +50,7 @@
 {% endblock header %}
 {% block content %}
     <section class="grid">
+        <div class="grid-sizer"></div>
         {% include "movie/movie_posters.html" %}
     </section>
     <script>
@@ -140,11 +160,12 @@
         }
 
         document.addEventListener("DOMContentLoaded", async (event) => {
-            const grid = document.querySelector('main');
+            const grid = document.querySelector('section.grid');
             masonry = new Masonry(grid, {
                 // options
                 itemSelector: '.grid-item',
-                columnWidth: 325
+                columnWidth: '.grid-sizer',
+                percentPosition: true
             });
             imagesLoaded(grid).on('progress', function() {
                 masonry.layout();

--- a/flask_backend/templates/movie/posters.html
+++ b/flask_backend/templates/movie/posters.html
@@ -13,6 +13,7 @@
         }
 
         @media (min-width: 400px) {
+
             .grid-sizer,
             .grid-item {
                 width: 25%;
@@ -20,6 +21,7 @@
         }
 
         @media (min-width: 700px) {
+
             .grid-sizer,
             .grid-item {
                 width: 325px;


### PR DESCRIPTION
## Summary
- Fixes #77 — on small screens the posters mosaic was stuck showing images in a single stacked column instead of a multi-column masonry grid.
- Root causes: the grid's `<style>` block lived outside any Jinja `{% block %}`, so it was silently dropped by template inheritance and never rendered; Masonry's `columnWidth` was hardcoded to `325`, ignoring viewport width; and the images' `height` HTML attribute (a presentational hint) locked their aspect ratio to the desktop size once width started shrinking, squishing them.
- Fix: moved the styles into the `meta_tags` block so they actually render, switched to a percent-based `.grid-sizer` reference element (3 columns by default, 4 columns from 400px, fixed 325px columns from 700px+), initialized Masonry directly on the item container (`section.grid`) so percentage widths resolve against the same containing block as the sizer, and added `height: auto` so images scale proportionally instead of squishing.

## Test plan
- [x] `uv run djlint flask_backend/templates/movie/posters.html --lint --profile=jinja`
- [x] `uv run pytest` (367 passed)
- [x] Manually verified in a live browser session at a 390px-wide viewport: items now cycle across 3 columns and each image's height scales proportionally with its width (no distortion)
- [x] Verified desktop layout (≥700px) still renders multi-column masonry as before