### PR TITLE
feat: allow delete-movie CLI command to accept a slug or id

### DIFF
--- a/flask_backend/commands.py
+++ b/flask_backend/commands.py
@@ -319,7 +319,7 @@ def title_cleaning_backfill_command(apply_):
 
 
 @click.command("delete-movie")
-@click.argument("movie_id", type=int)
+@click.argument("identifier")
 @click.option(
     "--yes",
     "-y",
@@ -327,8 +327,10 @@ def title_cleaning_backfill_command(apply_):
     default=False,
     help="Pula a confirmação e apaga direto.",
 )
-def delete_movie_command(movie_id, yes):
+def delete_movie_command(identifier, yes):
     """Apaga um filme e todos os registros relacionados (sessões, datas,
     tentativas de busca de poster/metadados, associações de gênero/diretor/país).
+
+    IDENTIFIER pode ser o id numérico ou o slug do filme.
     """
-    run_delete_movie(movie_id, skip_confirmation=yes)
+    run_delete_movie(identifier, skip_confirmation=yes)

--- a/flask_backend/scripts/delete_movie.py
+++ b/flask_backend/scripts/delete_movie.py
@@ -5,14 +5,18 @@ deleted - the Genre/Director/Country rows themselves are never touched, since
 they're shared across movies.
 
 Usage (via CLI):
-    flask delete-movie <id>          # prints the movie, asks for confirmation
-    flask delete-movie <id> --yes    # skips the confirmation prompt
+    flask delete-movie <id-or-slug>          # prints the movie, asks for confirmation
+    flask delete-movie <id-or-slug> --yes    # skips the confirmation prompt
 """
 
 import click
 
 from flask_backend.models import Movie
-from flask_backend.repository.movies import delete as delete_movie_row, get_by_id
+from flask_backend.repository.movies import (
+    delete as delete_movie_row,
+    get_by_id,
+    get_by_slug,
+)
 
 
 def _print_movie(movie: Movie) -> None:
@@ -48,10 +52,13 @@ def _print_movie(movie: Movie) -> None:
         )
 
 
-def delete_movie(movie_id: int, skip_confirmation: bool = False) -> bool:
-    movie = get_by_id(movie_id)
+def delete_movie(identifier: int | str, skip_confirmation: bool = False) -> bool:
+    is_id = isinstance(identifier, int) or (
+        isinstance(identifier, str) and identifier.isdigit()
+    )
+    movie = get_by_id(int(identifier)) if is_id else get_by_slug(identifier)
     if movie is None:
-        click.echo(f"Filme #{movie_id} não encontrado.", err=True)
+        click.echo(f"Filme '{identifier}' não encontrado.", err=True)
         return False
 
     _print_movie(movie)
@@ -67,5 +74,5 @@ def delete_movie(movie_id: int, skip_confirmation: bool = False) -> bool:
             return False
 
     delete_movie_row(movie)
-    click.echo(f"\nFilme #{movie_id} apagado com sucesso.")
+    click.echo(f"\nFilme #{movie.id} apagado com sucesso.")
     return True

--- a/flask_backend/tests/test_service/test_commands.py
+++ b/flask_backend/tests/test_service/test_commands.py
@@ -210,12 +210,17 @@ class TestThinWrapperCommands:
     def test_delete_movie_forwards_id_and_yes_flag(self, runner):
         with patch("flask_backend.commands.run_delete_movie") as mock_fn:
             runner.invoke(args=["delete-movie", "42", "--yes"])
-        mock_fn.assert_called_once_with(42, skip_confirmation=True)
+        mock_fn.assert_called_once_with("42", skip_confirmation=True)
 
     def test_delete_movie_without_yes_flag(self, runner):
         with patch("flask_backend.commands.run_delete_movie") as mock_fn:
             runner.invoke(args=["delete-movie", "42"])
-        mock_fn.assert_called_once_with(42, skip_confirmation=False)
+        mock_fn.assert_called_once_with("42", skip_confirmation=False)
+
+    def test_delete_movie_forwards_slug(self, runner):
+        with patch("flask_backend.commands.run_delete_movie") as mock_fn:
+            runner.invoke(args=["delete-movie", "filme-slug", "--yes"])
+        mock_fn.assert_called_once_with("filme-slug", skip_confirmation=True)
 
 
 class TestFetchPostersCommand:

--- a/flask_backend/tests/test_service/test_delete_movie.py
+++ b/flask_backend/tests/test_service/test_delete_movie.py
@@ -162,10 +162,48 @@ class TestDeleteMovieWithRelatedRows:
             )
 
 
+class TestDeleteMovieByIdentifierType:
+    def test_deletes_movie_by_numeric_id(self, client, app, setup_cinemas):
+        with client.application.app_context():
+            movie = _create_movie("Filme", "filme")
+            movie_id = movie.id
+
+            deleted = delete_movie(movie_id, skip_confirmation=True)
+
+            assert deleted is True
+            assert db_session.query(Movie).filter_by(id=movie_id).first() is None
+
+    def test_deletes_movie_by_numeric_id_as_string(self, client, app, setup_cinemas):
+        with client.application.app_context():
+            movie = _create_movie("Filme", "filme")
+            movie_id = movie.id
+
+            deleted = delete_movie(str(movie_id), skip_confirmation=True)
+
+            assert deleted is True
+            assert db_session.query(Movie).filter_by(id=movie_id).first() is None
+
+    def test_deletes_movie_by_slug(self, client, app, setup_cinemas):
+        with client.application.app_context():
+            movie = _create_movie("Filme", "filme-slug")
+            movie_id = movie.id
+
+            deleted = delete_movie("filme-slug", skip_confirmation=True)
+
+            assert deleted is True
+            assert db_session.query(Movie).filter_by(id=movie_id).first() is None
+
+
 class TestDeleteMovieNotFound:
-    def test_returns_false_without_changing_the_database(self, client, app):
+    def test_returns_false_without_changing_the_database_by_id(self, client, app):
         with client.application.app_context():
             deleted = delete_movie(999999, skip_confirmation=True)
+
+            assert deleted is False
+
+    def test_returns_false_without_changing_the_database_by_slug(self, client, app):
+        with client.application.app_context():
+            deleted = delete_movie("nao-existe", skip_confirmation=True)
 
             assert deleted is False
 


### PR DESCRIPTION
## Summary
- `flask delete-movie <identifier>` now accepts either the numeric movie id or its slug — numeric-looking identifiers resolve via id lookup, everything else via slug lookup.
- Not-found messages echo the identifier as given; the success message reports the resolved movie id.

## Test plan
- [x] `pytest flask_backend/tests` (491 passed)
- [x] `uv run ruff check --fix` / `uv run ruff format`
- [x] Manual smoke test against a scratch sqlite DB: delete by id, delete by slug, not-found by id, not-found by slug