### PR TITLE
feat: track mobile reels scroll and want-to-watch engagement via GoatCounter

### DIFF
--- a/flask_backend/static/reels-scroll-tracking.js
+++ b/flask_backend/static/reels-scroll-tracking.js
@@ -1,0 +1,21 @@
+const reelsCards = document.querySelectorAll(".reels-feed .reels-card");
+
+if (reelsCards.length > 1) {
+    const reelsScrollObserver = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (!entry.isIntersecting) return;
+                if (window.goatcounter) {
+                    window.goatcounter.count({
+                        path: window.location.pathname,
+                        title: "Reels scrolled past first card",
+                        event: true,
+                    });
+                }
+                reelsScrollObserver.disconnect();
+            });
+        },
+        { threshold: 0.5 }
+    );
+    reelsScrollObserver.observe(reelsCards[1]);
+}

--- a/flask_backend/static/reels-scroll-tracking.js
+++ b/flask_backend/static/reels-scroll-tracking.js
@@ -5,9 +5,9 @@ if (reelsCards.length > 1) {
         (entries) => {
             entries.forEach((entry) => {
                 if (!entry.isIntersecting) return;
-                if (window.goatcounter) {
+                if (window.goatcounter && window.goatcounter.count) {
                     window.goatcounter.count({
-                        path: window.location.pathname,
+                        path: "reels-scroll-past-first-card" + window.location.pathname,
                         title: "Reels scrolled past first card",
                         event: true,
                     });

--- a/flask_backend/static/reels-want-to-watch.js
+++ b/flask_backend/static/reels-want-to-watch.js
@@ -33,9 +33,9 @@ document.addEventListener("click", (event) => {
         .then((data) => {
             setWantToWatchState(button, data.wanted);
             if (data.wanted) {
-                if (window.goatcounter) {
+                if (window.goatcounter && window.goatcounter.count) {
                     window.goatcounter.count({
-                        path: window.location.pathname,
+                        path: "reels-want-to-watch-add",
                         title: "Marked movie as want-to-watch",
                         event: true,
                     });

--- a/flask_backend/static/reels-want-to-watch.js
+++ b/flask_backend/static/reels-want-to-watch.js
@@ -32,9 +32,18 @@ document.addEventListener("click", (event) => {
         })
         .then((data) => {
             setWantToWatchState(button, data.wanted);
-            if (data.wanted && !shownAddedHint) {
-                shownAddedHint = true;
-                showAddedToast();
+            if (data.wanted) {
+                if (window.goatcounter) {
+                    window.goatcounter.count({
+                        path: window.location.pathname,
+                        title: "Marked movie as want-to-watch",
+                        event: true,
+                    });
+                }
+                if (!shownAddedHint) {
+                    shownAddedHint = true;
+                    showAddedToast();
+                }
             }
         })
         .catch((error) => {

--- a/flask_backend/templates/base_reels.html
+++ b/flask_backend/templates/base_reels.html
@@ -124,6 +124,7 @@
     </script>
     <script src="{{ url_for('static', filename='halfmoon/bootstrap.bundle.js') }}"></script>
     <script src="{{ url_for('static', filename='reels-want-to-watch.js') }}"></script>
+    <script src="{{ url_for('static', filename='reels-scroll-tracking.js') }}"></script>
     <script>
         const lazyPosters = document.querySelectorAll(".reels-poster-img[data-src]");
         const posterObserver = new IntersectionObserver(


### PR DESCRIPTION
## Summary
- Fires a GoatCounter custom event the first time a visitor scrolls past the first card in the mobile reels feed (`flask_backend/static/reels-scroll-tracking.js`, wired into `base_reels.html`), via an `IntersectionObserver` that disconnects after the first hit.
- Fires a GoatCounter custom event when a movie is marked as want-to-watch (add only, not on unmark), added to the existing toggle handler in `flask_backend/static/reels-want-to-watch.js`.
- Both reuse the existing custom-event convention from `flask_backend/templates/movie/posters.html`, with distinct static `path` values per event (GoatCounter's `path` doubles as the event name, so each event needs its own identifier rather than the page URL) and a strengthened `if (window.goatcounter && window.goatcounter.count)` guard against the async-load race.
- No backend, DB, or build changes — purely client-side analytics additions.

## Test plan
- [x] `pytest` — 612 passed
- [x] `uv run djlint flask_backend/templates --lint --profile=jinja` — 0 errors
- [ ] Manual: open the mobile index (`/`) and `/favoritos` with a mobile user agent; in devtools, scrolling past the first card and tapping the want-to-watch star should each fire a GoatCounter event (check the Console locally, since `count.js` filters out localhost requests from the Network tab)