### PR TITLE
melhoria de fluxo no 'meus filmes'

### DIFF
--- a/flask_backend/static/css/favoritos.css
+++ b/flask_backend/static/css/favoritos.css
@@ -85,4 +85,5 @@
     border: 1px solid var(--bs-content-border-color);
     border-radius: 0.5rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    cursor: pointer;
 }

--- a/flask_backend/static/css/reels.css
+++ b/flask_backend/static/css/reels.css
@@ -261,6 +261,7 @@ body.reels-root {
     border: 1px solid var(--reels-hairline);
     border-radius: 0.5rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+    cursor: pointer;
 }
 
 .reels-wtw-toast .toast-body {

--- a/flask_backend/static/reels-want-to-watch.js
+++ b/flask_backend/static/reels-want-to-watch.js
@@ -1,4 +1,4 @@
-let shownAddedHint = false;
+let shownAddedHint = false
 
 function setWantToWatchState(button, wanted) {
     button.dataset.wanted = wanted ? "true" : "false";
@@ -14,6 +14,12 @@ function showAddedToast() {
     if (!toastEl) return;
     bootstrap.Toast.getOrCreateInstance(toastEl).show();
 }
+
+document.addEventListener("click", (event) => {
+    const toastEl = document.getElementById("reels-wtw-toast");
+    if (!toastEl || !toastEl.contains(event.target)) return;
+    window.location.href = "/favoritos";
+});
 
 document.addEventListener("click", (event) => {
     const button = event.target.closest('[data-function="want-to-watch"]');

--- a/flask_backend/templates/partials/site_menu.html
+++ b/flask_backend/templates/partials/site_menu.html
@@ -15,7 +15,7 @@
         </li>
         <li class="nav-item">
             <a class="nav-link {% if request.path == url_for("screening.favoritos") %}active{% endif %}"
-               href="{{ url_for("screening.favoritos") }}">Meus Filmes</a>
+               href="{{ url_for("screening.favoritos") }}">★ Meus Filmes</a>
         </li>
         <li>
             <hr class="my-2">


### PR DESCRIPTION
This pull request introduces several UI and interactivity improvements related to the "Favoritos" (Favorites) and "Want to Watch" features. The main changes focus on enhancing user experience by making clickable elements more visually clear, adding a shortcut to the favorites page, and improving the interaction with toast notifications.

**UI/UX Improvements:**

* Added `cursor: pointer;` to `.favorito-card` in `favoritos.css` and `.reels-card` in `reels.css` to indicate these cards are clickable, improving user feedback. [[1]](diffhunk://#diff-0b2c5ee5d26df1fb8edc482faddb7f4a0e44427249c0a15a51639d1d28b843c7R88) [[2]](diffhunk://#diff-400bbfce9bd2f6b52f1b556cbd12430c42ef04bdec2cddc0d4d19fc42d3d4fe6R264)
* Updated the "Meus Filmes" navigation link to include a star (★), making it stand out as the favorites section in the site menu.

**Interactivity Enhancements:**

* Added a click handler so that clicking the "Want to Watch" toast (`#reels-wtw-toast`) navigates the user directly to the `/favoritos` page, streamlining access to favorites.
* Minor cleanup: removed an unnecessary semicolon in `reels-want-to-watch.js`.